### PR TITLE
Add /speed OSC endpoint to control playspeed

### DIFF
--- a/src/ControlManager.cpp
+++ b/src/ControlManager.cpp
@@ -824,6 +824,12 @@ bool Control::receiveSourceAttribute(Source *target, const std::string &attribut
             arguments >> t >> osc::EndMessage;
             target->call( new Seek( t ), true );
         }
+        /// e.g. '/vimix/current/speed f 0.25'
+        else if ( attribute.compare(OSC_SOURCE_SPEED) == 0) {
+            float t = 0.f;
+            arguments >> t >> osc::EndMessage;
+            target->call( new PlaySpeed( t ), true );
+        }
         /// e.g. '/vimix/name/sync'
         else if ( attribute.compare(OSC_SYNC) == 0) {
             // this will require to send feedback status about source

--- a/src/ControlManager.h
+++ b/src/ControlManager.h
@@ -50,6 +50,7 @@
 #define OSC_SOURCE_SIZE        "/size"
 #define OSC_SOURCE_ANGLE       "/angle"
 #define OSC_SOURCE_SEEK        "/seek"
+#define OSC_SOURCE_SPEED       "/speed"
 #define OSC_SOURCE_BRIGHTNESS  "/brightness"
 #define OSC_SOURCE_CONTRAST    "/contrast"
 #define OSC_SOURCE_SATURATION  "/saturation"

--- a/src/UserInterfaceManager.cpp
+++ b/src/UserInterfaceManager.cpp
@@ -4390,7 +4390,7 @@ void SourceController::RenderMediaPlayer(MediaSource *ms)
             ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - buttons_height_ );
             // speed slider
             float speed = static_cast<float>(mediaplayer_active_->playSpeed());
-            if (ImGui::DragFloat( "##Speed", &speed, 0.01f, -10.f, 10.f, UNICODE_MULTIPLY " %.1f", 2.f))
+            if (ImGui::DragFloat( "##Speed", &speed, 0.01f, -10.f, 10.f, UNICODE_MULTIPLY " %.2f", 2.f))
                 mediaplayer_active_->setPlaySpeed( static_cast<double>(speed) );
             // store action on mouse release
             if (ImGui::IsItemDeactivatedAfterEdit()){
@@ -5832,7 +5832,7 @@ void InputMappingInterface::SliderParametersCallback(SourceCallback *callback, c
         float val = edited->value();
         ImGui::SetNextItemWidth(right_align);
         ImGui::SameLine(0, IMGUI_SAME_LINE / 2);
-        if (ImGui::SliderFloat("##CALLBACK_PLAYSPEED", &val, 0.1f, 20.f, "x %.1f"))
+        if (ImGui::SliderFloat("##CALLBACK_PLAYSPEED", &val, -10.f, 10.f, UNICODE_MULTIPLY " %.2f"))
             edited->setValue(val);
 
         ImGui::SameLine(0, IMGUI_SAME_LINE / 2);

--- a/src/UserInterfaceManager.cpp
+++ b/src/UserInterfaceManager.cpp
@@ -3146,20 +3146,19 @@ void SourceController::Render()
                     mediaplayer_active_->setRewindOnDisabled(true);
                 ImGui::EndMenu();
             }
-            if (Settings::application.render.gpu_decoding)
+            // always allow for hardware decoding to be disabled
+            ImGui::Separator();
+            if (ImGui::BeginMenu(ICON_FA_MICROCHIP "  Hardware decoding"))
             {
-                ImGui::Separator();
-                if (ImGui::BeginMenu(ICON_FA_MICROCHIP "  Hardware decoding"))
-                {
-                    bool hwdec = !mediaplayer_active_->softwareDecodingForced();
-                    if (ImGui::MenuItem("Auto", "", &hwdec ))
-                        mediaplayer_active_->setSoftwareDecodingForced(false);
-                    hwdec = mediaplayer_active_->softwareDecodingForced();
-                    if (ImGui::MenuItem("Disabled", "", &hwdec ))
-                        mediaplayer_active_->setSoftwareDecodingForced(true);
-                    ImGui::EndMenu();
-                }
+                bool hwdec = !mediaplayer_active_->softwareDecodingForced();
+                if (ImGui::MenuItem("Auto", "", &hwdec ))
+                    mediaplayer_active_->setSoftwareDecodingForced(false);
+                hwdec = mediaplayer_active_->softwareDecodingForced();
+                if (ImGui::MenuItem("Disabled", "", &hwdec ))
+                    mediaplayer_active_->setSoftwareDecodingForced(true);
+                ImGui::EndMenu();
             }
+            
 
             ImGui::EndMenu();
         }

--- a/src/snippets.cpp
+++ b/src/snippets.cpp
@@ -256,7 +256,7 @@ void drawMediaPlayer()
     ImGui::SameLine(0, spacing);
     ImGui::SetNextItemWidth(270);
     // ImGui::SetNextItemWidth(width - 90.0);
-    if (ImGui::SliderFloat( "Speed", &speed, -10.f, 10.f, "x %.1f", 2.f))
+    if (ImGui::SliderFloat( "Speed", &speed, -10.f, 10.f, "x %.2f", 2.f))
         testmedia.setPlaySpeed( static_cast<double>(speed) );
     ImGui::SameLine(0, spacing);
     if (ImGuiToolkit::ButtonIcon(19, 15)) {


### PR DESCRIPTION
Needed for my upcoming show. :)

Allow for OSC control of playspeed. Change precision of playback speed to 2 decimals. (My use case is slightly nudging the playspeed to align to live music.)

Things to review, that I'm not sure about:

- I wasn't sure what `snippets.cpp` was so that change may be wrong/unneeded. 
- If "/speed" or "/rate" or "/playspeed" should be used, but the UI calls it speed so used that.
- line 5835: couldn't figure out where this UI was to test it, but unified the parameters with the other DragFloat.