### PR TITLE
Add "#include <algorithm>" to 4 files

### DIFF
--- a/src/DisplaysView.cpp
+++ b/src/DisplaysView.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <sstream>
 #include <iomanip>
+#include <algorithm>
 
 
 #include <glad/glad.h>

--- a/src/SessionCreator.cpp
+++ b/src/SessionCreator.cpp
@@ -18,6 +18,7 @@
 **/
 
 #include <sstream>
+#include <algorithm>
 
 #include "Log.h"
 #include "defines.h"

--- a/src/SourceCallback.cpp
+++ b/src/SourceCallback.cpp
@@ -17,6 +17,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
 **/
 #include <fstream>
+#include <algorithm>
 
 #include "defines.h"
 #include "Source.h"

--- a/src/SourceControlWindow.cpp
+++ b/src/SourceControlWindow.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <iomanip>
 #include <thread>
+#include <algorithm>
 
 #include <gst/gst.h>
 


### PR DESCRIPTION
Added `#include <algorithm>` to the following files in src/: DisplaysView.cpp, SessionCreator.cpp, SourceCallback.cpp and SourceControlWindow.cpp. These files were returning errors when building vimix from source.