### PR TITLE
Fix the 32-bit build

### DIFF
--- a/ext/OSCPack/osc/OscReceivedElements.h
+++ b/ext/OSCPack/osc/OscReceivedElements.h
@@ -100,6 +100,11 @@ public:
         : contents_( contents )
         , size_( ValidateSize( (osc_bundle_element_size_t)size ) ) {}
 
+#if !(defined(__LP64__) || defined(_LP64) || defined(__SIZEOF_POINTER__) && __SIZEOF_POINTER__ == 8)
+    ReceivedPacket( const char *contents, int size )
+        : contents_( contents )
+        , size_( ValidateSize( (osc_bundle_element_size_t)size ) ) {}
+#endif
 
     bool IsMessage() const { return !IsBundle(); }
     bool IsBundle() const;


### PR DESCRIPTION
@brunoherbelin This fixes the 32-bit build broken by commit 1ffb514:
https://buildd.debian.org/status/fetch.php?pkg=vimix&arch=i386&ver=0.9.0%2Bgit20260228%2Bds-1&stamp=1772408000&raw=0
```
In file included from /build/reproducible-path/vimix-0.9.0+git20260228+ds/src/Streamer.h:8,
                 from /build/reproducible-path/vimix-0.9.0+git20260228+ds/src/Connection.cpp:31:
/build/reproducible-path/vimix-0.9.0+git20260228+ds/ext/OSCPack/osc/OscPacketListener.h: In member function ‘virtual void osc::OscPacketListener::ProcessPacket(const char*, int, const IpEndpointName&)’:
/build/reproducible-path/vimix-0.9.0+git20260228+ds/ext/OSCPack/osc/OscPacketListener.h:69:43: error: call of overloaded ‘ReceivedPacket(const char*&, int&)’ is ambiguous
   69 |         osc::ReceivedPacket p( data, size );
      |                                           ^
/build/reproducible-path/vimix-0.9.0+git20260228+ds/ext/OSCPack/osc/OscPacketListener.h:69:43: note: there are 2 candidates
In file included from /build/reproducible-path/vimix-0.9.0+git20260228+ds/src/Streamer.h:7:
/build/reproducible-path/vimix-0.9.0+git20260228+ds/ext/OSCPack/osc/OscReceivedElements.h:99:5: note: candidate 1: ‘osc::ReceivedPacket::ReceivedPacket(const char*, std::size_t)’
   99 |     ReceivedPacket( const char *contents, std::size_t size )
      |     ^~~~~~~~~~~~~~
/build/reproducible-path/vimix-0.9.0+git20260228+ds/ext/OSCPack/osc/OscReceivedElements.h:95:5: note: candidate 2: ‘osc::ReceivedPacket::ReceivedPacket(const char*, osc::osc_bundle_element_size_t)’
   95 |     ReceivedPacket( const char *contents, osc_bundle_element_size_t size )
      |     ^~~~~~~~~~~~~~
In file included from /build/reproducible-path/vimix-0.9.0+git20260228+ds/src/ControlManager.h:12,
                 from /build/reproducible-path/vimix-0.9.0+git20260228+ds/src/main.cpp:32:
/build/reproducible-path/vimix-0.9.0+git20260228+ds/ext/OSCPack/osc/OscPacketListener.h: In member function ‘virtual void osc::OscPacketListener::ProcessPacket(const char*, int, const IpEndpointName&)’:
/build/reproducible-path/vimix-0.9.0+git20260228+ds/ext/OSCPack/osc/OscPacketListener.h:69:43: error: call of overloaded ‘ReceivedPacket(const char*&, int&)’ is ambiguous
   69 |         osc::ReceivedPacket p( data, size );
      |                                           ^
/build/reproducible-path/vimix-0.9.0+git20260228+ds/ext/OSCPack/osc/OscPacketListener.h:69:43: note: there are 2 candidates
In file included from /build/reproducible-path/vimix-0.9.0+git20260228+ds/src/ControlManager.h:11:
/build/reproducible-path/vimix-0.9.0+git20260228+ds/ext/OSCPack/osc/OscReceivedElements.h:99:5: note: candidate 1: ‘osc::ReceivedPacket::ReceivedPacket(const char*, std::size_t)’
   99 |     ReceivedPacket( const char *contents, std::size_t size )
      |     ^~~~~~~~~~~~~~
/build/reproducible-path/vimix-0.9.0+git20260228+ds/ext/OSCPack/osc/OscReceivedElements.h:95:5: note: candidate 2: ‘osc::ReceivedPacket::ReceivedPacket(const char*, osc::osc_bundle_element_size_t)’
   95 |     ReceivedPacket( const char *contents, osc_bundle_element_size_t size )
      |     ^~~~~~~~~~~~~~
```

@alexmyczko FYI